### PR TITLE
Task 2.5: Implement WildcardImportDetector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xfile-context"
-version = "0.0.24"
+version = "0.0.25"
 description = "Cross-File Context Links MCP Server"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/xfile_context/__init__.py
+++ b/src/xfile_context/__init__.py
@@ -5,7 +5,7 @@
 
 from .storage import GraphExport, InMemoryStore, RelationshipStore
 
-__version__ = "0.0.12"
+__version__ = "0.0.25"
 
 __all__ = [
     "RelationshipStore",

--- a/src/xfile_context/detectors/__init__.py
+++ b/src/xfile_context/detectors/__init__.py
@@ -11,6 +11,7 @@ Components:
 - DetectorRegistry: Priority-based registry for detector plugins
 - ImportDetector: Detector for import relationships
 - ConditionalImportDetector: Detector for conditional import relationships
+- WildcardImportDetector: Detector for wildcard import relationships
 
 See TDD Section 3.4.4 for detailed specifications.
 """
@@ -19,10 +20,12 @@ from .base import RelationshipDetector
 from .conditional_import_detector import ConditionalImportDetector
 from .import_detector import ImportDetector
 from .registry import DetectorRegistry
+from .wildcard_import_detector import WildcardImportDetector
 
 __all__ = [
     "RelationshipDetector",
     "DetectorRegistry",
     "ImportDetector",
     "ConditionalImportDetector",
+    "WildcardImportDetector",
 ]

--- a/src/xfile_context/detectors/wildcard_import_detector.py
+++ b/src/xfile_context/detectors/wildcard_import_detector.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2025 Henru Wang
+# All rights reserved.
+
+"""Wildcard import relationship detector plugin.
+
+This module implements the WildcardImportDetector plugin that detects wildcard
+import relationships (from module import *) with module-level tracking limitations.
+
+Supports:
+- from module import * (wildcard imports)
+- Module-level tracking (cannot track specific imported names)
+- Optional warning via warn_on_wildcards configuration
+- Context injection noting the limitation
+
+The relationships are tracked as IMPORT type but include metadata indicating
+they are wildcard imports with tracking limitations.
+
+See TDD Section 3.5.2.6 (EC-4) for detailed specifications.
+"""
+
+import ast
+import logging
+from typing import List
+
+from ..models import Relationship
+from .base import RelationshipDetector
+from .import_detector import ImportDetector
+
+logger = logging.getLogger(__name__)
+
+
+class WildcardImportDetector(RelationshipDetector):
+    """Detector for wildcard import relationships in Python code.
+
+    Detects wildcard import statements (from module import *) and marks them
+    with wildcard metadata. Implements the detector plugin pattern from DD-1.
+
+    Patterns Detected:
+    - from module import * (wildcard imports)
+
+    Wildcard Detection (TDD Section 3.5.2.6, EC-4):
+    - Tracks at module level only
+    - Cannot determine which specific names were imported
+    - Optional warning via warn_on_wildcards configuration (default: false)
+    - Context injection explains limitation
+
+    Metadata includes:
+    - wildcard: "true"
+    - limitation: Description of tracking limitation
+
+    Priority: 90 (Runs after ConditionalImportDetector)
+
+    See TDD Section 3.5.2.6 for detailed specifications.
+    """
+
+    def __init__(self, warn_on_wildcards: bool = False) -> None:
+        """Initialize the WildcardImportDetector.
+
+        Args:
+            warn_on_wildcards: Whether to emit warnings for wildcard imports.
+                              Default is False per Code Style Philosophy (PRD 2.5).
+        """
+        # Use ImportDetector for module resolution logic
+        self._import_detector = ImportDetector()
+        self._warn_on_wildcards = warn_on_wildcards
+
+    def detect(
+        self,
+        node: ast.AST,
+        filepath: str,
+        module_ast: ast.Module,
+    ) -> List[Relationship]:
+        """Detect wildcard import relationships in an AST node.
+
+        Args:
+            node: AST node to analyze.
+            filepath: Absolute path to the file being analyzed.
+            module_ast: The root AST node of the entire module (for context).
+
+        Returns:
+            List of detected wildcard import relationships. Empty list if no
+            wildcard imports found.
+        """
+        relationships: List[Relationship] = []
+
+        # Only process ImportFrom nodes (wildcard imports use this pattern)
+        if not isinstance(node, ast.ImportFrom):
+            return relationships
+
+        # Check if this is a wildcard import: from module import *
+        # Wildcard is represented by a single alias with name='*'
+        if not self._is_wildcard_import(node):
+            return relationships
+
+        # Use ImportDetector to detect the import and resolve module
+        try:
+            import_rels = self._import_detector.detect(node, filepath, module_ast)
+        except Exception as e:
+            # Malformed AST or resolution error, skip gracefully
+            logger.debug(f"Error detecting wildcard import in {filepath}: {e}")
+            return relationships
+
+        # Enhance each relationship with wildcard metadata
+        for rel in import_rels:
+            # Ensure metadata dict exists (ImportDetector always creates it)
+            if rel.metadata is None:
+                rel.metadata = {}
+
+            # For wildcard imports, target_symbol should be the module name, not "*"
+            # This is because we're tracking the module-level dependency (TDD 3.5.2.6)
+            # The module name is stored in metadata by ImportDetector
+            if "module_name" in rel.metadata:
+                # Use the module name as target_symbol for better clarity
+                # For absolute imports: module_name is the actual module (e.g., "os")
+                # For relative imports: module_name might be empty or "." notation
+                module_name = rel.metadata["module_name"]
+                if module_name and module_name != "." and module_name != "..":
+                    rel.target_symbol = module_name
+                elif not module_name and "relative_level" in rel.metadata:
+                    # Keep the existing target_symbol for relative imports without module
+                    # (e.g., "from . import *" - target_symbol stays as is)
+                    pass
+
+            # Add wildcard metadata (all values must be strings per metadata type)
+            rel.metadata["wildcard"] = "true"
+            rel.metadata["limitation"] = (
+                "Cannot track which specific names are imported from this module"
+            )
+
+            # Emit warning if configured to do so
+            if self._warn_on_wildcards:
+                # Get module name for warning message
+                module_name = node.module if node.module else "<relative>"
+                logger.warning(
+                    f"Wildcard import detected in {filepath}:{node.lineno}: "
+                    f"from {module_name} import * - "
+                    f"Cannot track specific names imported (EC-4)"
+                )
+
+            relationships.append(rel)
+
+        return relationships
+
+    def _is_wildcard_import(self, node: ast.ImportFrom) -> bool:
+        """Check if an ImportFrom node is a wildcard import.
+
+        Args:
+            node: ImportFrom AST node to check.
+
+        Returns:
+            True if this is a wildcard import (from X import *), False otherwise.
+        """
+        # Wildcard imports have a single alias with name='*'
+        # Example AST: ImportFrom(module='os', names=[alias(name='*', asname=None)])
+        return bool(
+            node.names
+            and len(node.names) == 1
+            and hasattr(node.names[0], "name")
+            and node.names[0].name == "*"
+        )
+
+    def priority(self) -> int:
+        """Return detector priority.
+
+        WildcardImportDetector has priority 90, running after ConditionalImportDetector (95)
+        and ImportDetector (100). This allows it to catch wildcard imports that weren't
+        already handled by more specific detectors.
+
+        Returns:
+            Priority value (90).
+        """
+        return 90
+
+    def name(self) -> str:
+        """Return detector name.
+
+        Returns:
+            Detector name: "WildcardImportDetector".
+        """
+        return "WildcardImportDetector"

--- a/tests/test_wildcard_import_detector.py
+++ b/tests/test_wildcard_import_detector.py
@@ -1,0 +1,428 @@
+# Copyright (c) 2025 Henru Wang
+# All rights reserved.
+
+"""Tests for WildcardImportDetector plugin.
+
+Tests cover:
+- Wildcard import detection (from module import *)
+- Module-level tracking
+- Wildcard metadata marking
+- Warning configuration (warn_on_wildcards)
+- Edge cases
+"""
+
+import ast
+import logging
+
+from xfile_context.detectors import WildcardImportDetector
+from xfile_context.models import RelationshipType
+
+
+class TestWildcardImportDetectorBasics:
+    """Tests for basic wildcard import detector functionality."""
+
+    def test_detector_name(self):
+        """Test detector name is 'WildcardImportDetector'."""
+        detector = WildcardImportDetector()
+        assert detector.name() == "WildcardImportDetector"
+
+    def test_detector_priority(self):
+        """Test detector has priority 90 (after ConditionalImportDetector)."""
+        detector = WildcardImportDetector()
+        assert detector.priority() == 90
+
+    def test_no_wildcards_returns_empty_list(self):
+        """Test that code with no wildcard imports returns empty relationship list."""
+        detector = WildcardImportDetector()
+        code = """
+import os
+from typing import List
+x = 1
+"""
+        tree = ast.parse(code)
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert relationships == []
+
+    def test_regular_from_import_not_detected(self):
+        """Test that regular from imports are not detected as wildcards."""
+        detector = WildcardImportDetector()
+        code = """
+from os import path
+from typing import List, Dict
+"""
+        tree = ast.parse(code)
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert relationships == []
+
+    def test_import_statement_not_detected(self):
+        """Test that regular import statements are not detected as wildcards."""
+        detector = WildcardImportDetector()
+        code = """
+import os
+import sys
+"""
+        tree = ast.parse(code)
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert relationships == []
+
+
+class TestWildcardImportDetection:
+    """Tests for wildcard import detection."""
+
+    def test_wildcard_import_stdlib(self):
+        """Test detection of 'from os import *' pattern (stdlib module)."""
+        detector = WildcardImportDetector()
+        code = """
+from os import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should have 1 wildcard import relationship
+        assert len(relationships) == 1
+        rel = relationships[0]
+
+        assert rel.relationship_type == RelationshipType.IMPORT
+        assert rel.source_file == "/test/file.py"
+        assert rel.target_file == "<stdlib:os>"
+        assert rel.target_symbol == "os"
+        assert rel.metadata["wildcard"] == "true"
+        assert "Cannot track which specific names" in rel.metadata["limitation"]
+
+    def test_wildcard_import_third_party(self):
+        """Test detection of wildcard import from third-party module."""
+        detector = WildcardImportDetector()
+        code = """
+from django.contrib import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert len(relationships) == 1
+        rel = relationships[0]
+
+        assert rel.relationship_type == RelationshipType.IMPORT
+        # Third-party modules that aren't in project are marked as unresolved
+        assert rel.target_file == "<unresolved:django.contrib>"
+        assert rel.target_symbol == "django.contrib"
+        assert rel.metadata["wildcard"] == "true"
+
+    def test_wildcard_import_relative(self):
+        """Test detection of relative wildcard import."""
+        detector = WildcardImportDetector()
+        code = """
+from . import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert len(relationships) == 1
+        rel = relationships[0]
+
+        assert rel.relationship_type == RelationshipType.IMPORT
+        assert rel.metadata["wildcard"] == "true"
+
+    def test_wildcard_import_parent_relative(self):
+        """Test detection of parent-relative wildcard import."""
+        detector = WildcardImportDetector()
+        code = """
+from .. import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert len(relationships) == 1
+        rel = relationships[0]
+
+        assert rel.relationship_type == RelationshipType.IMPORT
+        assert rel.metadata["wildcard"] == "true"
+
+    def test_multiple_wildcard_imports(self):
+        """Test multiple wildcard imports in same file."""
+        detector = WildcardImportDetector()
+        code = """
+from os import *
+from sys import *
+from typing import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should have 3 wildcard import relationships
+        assert len(relationships) == 3
+
+        # Check all are marked as wildcard
+        for rel in relationships:
+            assert rel.relationship_type == RelationshipType.IMPORT
+            assert rel.metadata["wildcard"] == "true"
+
+        # Check imported modules
+        imported_modules = {rel.target_symbol for rel in relationships}
+        assert imported_modules == {"os", "sys", "typing"}
+
+
+class TestWildcardWarningConfiguration:
+    """Tests for warn_on_wildcards configuration."""
+
+    def test_warning_disabled_by_default(self, caplog):
+        """Test that warnings are disabled by default (warn_on_wildcards=False)."""
+        detector = WildcardImportDetector()
+        code = """
+from os import *
+"""
+        tree = ast.parse(code)
+
+        with caplog.at_level(logging.WARNING):
+            relationships = []
+            for node in ast.walk(tree):
+                relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should detect the wildcard import
+        assert len(relationships) == 1
+
+        # Should not emit warning (default behavior per PRD 2.5)
+        assert not any("Wildcard import detected" in record.message for record in caplog.records)
+
+    def test_warning_enabled_explicitly(self, caplog):
+        """Test that warnings are emitted when warn_on_wildcards=True."""
+        detector = WildcardImportDetector(warn_on_wildcards=True)
+        code = """
+from os import *
+"""
+        tree = ast.parse(code)
+
+        with caplog.at_level(logging.WARNING):
+            relationships = []
+            for node in ast.walk(tree):
+                relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should detect the wildcard import
+        assert len(relationships) == 1
+
+        # Should emit warning with EC-4 reference
+        warning_found = False
+        for record in caplog.records:
+            if "Wildcard import detected" in record.message and "EC-4" in record.message:
+                assert "/test/file.py" in record.message
+                assert "from os import *" in record.message
+                warning_found = True
+                break
+
+        assert warning_found, "Expected wildcard import warning not found in logs"
+
+    def test_warning_includes_line_number(self, caplog):
+        """Test that warning includes line number."""
+        detector = WildcardImportDetector(warn_on_wildcards=True)
+        code = """# Line 1
+# Line 2
+from os import *  # Line 3
+"""
+        tree = ast.parse(code)
+
+        with caplog.at_level(logging.WARNING):
+            relationships = []
+            for node in ast.walk(tree):
+                relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should have warning with line number 3
+        warning_found = False
+        for record in caplog.records:
+            if "Wildcard import detected" in record.message:
+                # Line number should be in format "file.py:3"
+                assert ":3:" in record.message or "line 3" in record.message.lower()
+                warning_found = True
+                break
+
+        assert warning_found
+
+    def test_warning_for_relative_import(self, caplog):
+        """Test warning message for relative wildcard import."""
+        detector = WildcardImportDetector(warn_on_wildcards=True)
+        code = """
+from . import *
+"""
+        tree = ast.parse(code)
+
+        with caplog.at_level(logging.WARNING):
+            relationships = []
+            for node in ast.walk(tree):
+                relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should emit warning mentioning relative import
+        warning_found = False
+        for record in caplog.records:
+            if "Wildcard import detected" in record.message:
+                # Should mention relative import
+                assert "from" in record.message and "import *" in record.message
+                warning_found = True
+                break
+
+        assert warning_found
+
+
+class TestWildcardMetadata:
+    """Tests for wildcard import metadata."""
+
+    def test_metadata_includes_wildcard_flag(self):
+        """Test that metadata includes wildcard=true flag."""
+        detector = WildcardImportDetector()
+        code = """
+from os import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert len(relationships) == 1
+        assert relationships[0].metadata["wildcard"] == "true"
+
+    def test_metadata_includes_limitation_message(self):
+        """Test that metadata includes limitation explanation."""
+        detector = WildcardImportDetector()
+        code = """
+from os import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert len(relationships) == 1
+        limitation = relationships[0].metadata["limitation"]
+        assert "Cannot track which specific names" in limitation
+        assert "imported" in limitation.lower()
+
+    def test_metadata_all_string_values(self):
+        """Test that all metadata values are strings (per metadata type requirement)."""
+        detector = WildcardImportDetector()
+        code = """
+from os import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert len(relationships) == 1
+        rel = relationships[0]
+
+        # All metadata values must be strings
+        for key, value in rel.metadata.items():
+            assert isinstance(
+                value, str
+            ), f"Metadata key '{key}' has non-string value: {type(value)}"
+
+
+class TestWildcardEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_wildcard_with_other_imports(self):
+        """Test wildcard import mixed with regular imports."""
+        detector = WildcardImportDetector()
+        code = """
+import os
+from sys import path
+from typing import *
+from collections import defaultdict
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should only detect the wildcard import
+        assert len(relationships) == 1
+        assert relationships[0].target_symbol == "typing"
+        assert relationships[0].metadata["wildcard"] == "true"
+
+    def test_wildcard_in_function(self):
+        """Test wildcard import inside function (not module level)."""
+        detector = WildcardImportDetector()
+        code = """
+def foo():
+    from os import *
+    return path
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should still detect the wildcard import
+        # (even though it's not at module level, it's still an import)
+        assert len(relationships) == 1
+        assert relationships[0].metadata["wildcard"] == "true"
+
+    def test_wildcard_in_conditional(self):
+        """Test wildcard import in conditional block."""
+        detector = WildcardImportDetector()
+        code = """
+if True:
+    from os import *
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        # Should detect the wildcard import
+        assert len(relationships) == 1
+        assert relationships[0].metadata["wildcard"] == "true"
+
+    def test_empty_file(self):
+        """Test empty file produces no relationships."""
+        detector = WildcardImportDetector()
+        code = ""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert relationships == []
+
+    def test_comments_only(self):
+        """Test file with only comments produces no relationships."""
+        detector = WildcardImportDetector()
+        code = """
+# This is a comment
+# Another comment
+"""
+        tree = ast.parse(code)
+
+        relationships = []
+        for node in ast.walk(tree):
+            relationships.extend(detector.detect(node, "/test/file.py", tree))
+
+        assert relationships == []


### PR DESCRIPTION
## Summary
- Implements wildcard import detection (`from module import *`)
- Tracks imports at module level with limitations noted in metadata
- Adds configurable warning support via `warn_on_wildcards` (default: false)
- Follows detector plugin pattern with priority 90
- Comprehensive test coverage (22 tests)

## Implementation Details
**Files Created:**
- `src/xfile_context/detectors/wildcard_import_detector.py`: Main detector implementation
- `tests/test_wildcard_import_detector.py`: Complete test suite

**Files Modified:**
- `src/xfile_context/detectors/__init__.py`: Added WildcardImportDetector export
- `pyproject.toml`: Version bump to 0.0.25
- `src/xfile_context/__init__.py`: Version bump to 0.0.25

**Key Features:**
- Detects `from module import *` patterns
- Module-level tracking only (cannot track individual imported names)
- Metadata includes `wildcard: "true"` and limitation explanation
- Optional warning emission (configurable, defaults to false per PRD 2.5)
- Reuses ImportDetector for module resolution
- Corrects target_symbol to show module name instead of literal "*"

**Test Coverage:**
- Basic detector functionality (name, priority, filtering)
- Wildcard import detection (stdlib, third-party, relative imports)
- Warning configuration (enabled/disabled, line numbers)
- Metadata validation (flags, limitation messages, type safety)
- Edge cases (mixed imports, conditionals, functions)

## Test Plan
- [x] All existing tests pass (189 total)
- [x] New wildcard detector tests pass (22 tests)
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, pytest)
- [x] Version updated to 0.0.25 (Task 2.5)
- [ ] CI/CD checks pass
- [ ] Multi-agent review completed

## References
- Closes #16
- TDD Section 3.5.2.6 (Wildcard Import Detection)
- PRD Section 2.5 (Code Style Philosophy - warning defaults)
- EC-4 (wildcard imports with limitations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)