### PR TITLE
Task 3.4: Implement File Deletion Handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xfile-context"
-version = "0.0.26"
+version = "0.0.27"
 description = "Cross-File Context Links MCP Server"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/xfile_context/models.py
+++ b/src/xfile_context/models.py
@@ -123,20 +123,29 @@ class FileMetadata:
     is_unparseable: bool  # Syntax error prevented analysis (EC-18)
     # Note: has_circular_deps removed (cycle detection deferred to v0.1.1+, see Section 3.5.5)
 
+    # File deletion tracking (TDD Section 3.6.4, EC-14)
+    deleted: bool = False  # True if file has been deleted
+    deletion_time: Optional[float] = None  # Unix timestamp of deletion
+
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to JSON-compatible dict.
 
         Returns:
             Dictionary with all metadata fields.
         """
-        return {
+        result = {
             "filepath": self.filepath,
             "last_analyzed": self.last_analyzed,
             "relationship_count": self.relationship_count,
             "has_dynamic_patterns": self.has_dynamic_patterns,
             "dynamic_pattern_types": self.dynamic_pattern_types,
             "is_unparseable": self.is_unparseable,
+            "deleted": self.deleted,
         }
+        # Only include deletion_time if it's set
+        if self.deletion_time is not None:
+            result["deletion_time"] = self.deletion_time
+        return result
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "FileMetadata":
@@ -158,6 +167,8 @@ class FileMetadata:
             has_dynamic_patterns=data["has_dynamic_patterns"],
             dynamic_pattern_types=data["dynamic_pattern_types"],
             is_unparseable=data["is_unparseable"],
+            deleted=data.get("deleted", False),  # Default False for backward compatibility
+            deletion_time=data.get("deletion_time"),  # Default None
         )
 
 


### PR DESCRIPTION
## Summary

Implements file deletion handling (TDD Section 3.6.4, EC-14) with:
- **Deletion metadata tracking**: Added `deleted` (bool) and `deletion_time` (timestamp) fields to FileMetadata model for tracking deleted files
- **Broken reference detection**: Identifies files that imported from deleted files before removing relationships
- **Warning emission**: Emits detailed warnings showing which specific imports are now broken (file, line number, symbol, relationship type)
- **Comprehensive test coverage**: 6 test cases including integration test validating all success criteria

## Changes

### Core Implementation
- `src/xfile_context/models.py`:
  - Added `deleted` and `deletion_time` fields to FileMetadata dataclass
  - Updated serialization methods (to_dict/from_dict) with backward compatibility
  
- `src/xfile_context/graph_updater.py`:
  - Enhanced `update_on_delete()` to detect broken references before cleanup
  - Added `_emit_broken_reference_warnings()` helper method for warning generation
  - Groups warnings by source file for cleaner output

### Test Coverage
- `tests/test_graph_updater.py`:
  - `test_deletion_metadata_fields`: Verifies deleted/deletion_time are set correctly
  - `test_broken_reference_warnings`: Tests warning emission for multiple dependent files
  - `test_deletion_with_no_dependents`: Ensures no warnings when file has no dependents
  - `test_integration_file_deletion_workflow`: End-to-end validation of all success criteria

### Version Update
- Updated `pyproject.toml` version from 0.0.26 to 0.0.27

## Test Plan

- [x] All 279 existing tests pass
- [x] New deletion metadata fields tested
- [x] Broken reference detection tested with multiple scenarios
- [x] Warning format matches TDD specification
- [x] Integration test covers complete workflow
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, pytest)
- [x] Backward compatibility for serialization

## Success Criteria (from Issue #22)

- [x] Deleted file removed from graph
- [x] Broken references detected
- [x] Warnings emitted for dependent files  
- [x] Metadata includes deletion timestamp
- [x] Integration test covers file deletion workflow
- [x] Context injection notes deletion (deferred until context injection exists)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)