### PR TITLE
Task 4.5: Implement Context Injection Formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xfile-context"
-version = "0.0.44"
+version = "0.0.45"
 description = "Cross-File Context Links MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Implements context injection formatting per TDD Section 3.8.3
- Adds cache age indicator ("last read: X minutes ago") 
- Shows implementation line ranges (e.g., `:45-67`)
- Includes short docstrings (<50 chars) in snippets
- Handles special cases: wildcard imports (EC-4), large functions (EC-12), deleted files (EC-14)
- Adds 18 comprehensive unit tests (T-2.2) for all format components

## Test plan
- [x] All existing tests pass (410 tests)
- [x] New formatting tests pass (18 tests in TestContextInjectionFormatting)
- [x] New signature extraction tests pass (5 tests in TestFunctionSignatureExtraction)
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, pytest)
- [x] Visual inspection confirms readable output format

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)