### PR TITLE
Implement Relationship Graph Export (Task 6.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xfile-context"
-version = "0.0.62"
+version = "0.0.63"
 description = "Cross-File Context Links MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/xfile_context/service.py
+++ b/src/xfile_context/service.py
@@ -1169,10 +1169,16 @@ class CrossFileContextService:
     def get_relationship_graph(self) -> GraphExport:
         """Get the full relationship graph for export.
 
+        Returns the full graph export per TDD Section 3.10.3 with:
+        - metadata: timestamp, version, language, project_root, counts
+        - files: list of file info with absolute and relative paths
+        - relationships: all detected relationships with full metadata
+        - graph_metadata: circular imports, most connected files
+
         Returns:
             GraphExport object with current graph state (FR-23, FR-25).
         """
-        return self.store.export_graph()
+        return self._graph.export_to_dict(project_root=str(self._project_root))
 
     def get_dependents(self, file_path: str) -> List[Dict[str, Any]]:
         """Get files that depend on the given file.


### PR DESCRIPTION
## Summary
- Implements TDD Section 3.10.3 relationship graph export functionality
- Enhanced `RelationshipGraph.export_to_dict()` to include full export structure with metadata, files, relationships, and graph_metadata
- Updated `InMemoryStore.export_graph()` to match new interface
- Added helper methods for relative path computation and most-connected files
- Updated service layer `get_relationship_graph()` to pass project_root
- Added comprehensive tests for T-4.5, T-4.6, T-4.7

## Test plan
- [x] All 671 tests pass
- [x] Pre-commit checks pass (black, isort, ruff, mypy, pytest)
- [x] Graph export produces valid JSON (T-4.5)
- [x] Export contains all required TDD 3.10.3 fields (T-4.6)
- [x] External tools can parse and analyze exported graph (T-4.7)
- [x] Both absolute and relative paths included when project_root provided
- [x] Most connected files sorted by dependency count

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)