### PR TITLE
Task 7.3.3: Implement T-2 Context Injection Tests

### DIFF
--- a/tests/functional/test_context_injection.py
+++ b/tests/functional/test_context_injection.py
@@ -44,8 +44,11 @@ def ground_truth() -> dict[str, Any]:
 
 
 @pytest.fixture
-def default_config() -> Config:
-    """Create default configuration for tests."""
+def default_config():
+    """Create default configuration for tests.
+
+    Yields config and cleans up temporary file after test completes.
+    """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
         f.write("enable_context_injection: true\n")
         f.write("context_token_limit: 500\n")
@@ -53,29 +56,44 @@ def default_config() -> Config:
         f.write("cache_size_limit_kb: 50\n")
         config_path = Path(f.name)
 
-    return Config(config_path)
+    yield Config(config_path)
+
+    # Cleanup temporary config file
+    config_path.unlink(missing_ok=True)
 
 
 @pytest.fixture
-def disabled_injection_config() -> Config:
-    """Create configuration with context injection disabled."""
+def disabled_injection_config():
+    """Create configuration with context injection disabled.
+
+    Yields config and cleans up temporary file after test completes.
+    """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
         f.write("enable_context_injection: false\n")
         f.write("context_token_limit: 500\n")
         config_path = Path(f.name)
 
-    return Config(config_path)
+    yield Config(config_path)
+
+    # Cleanup temporary config file
+    config_path.unlink(missing_ok=True)
 
 
 @pytest.fixture
-def low_token_limit_config() -> Config:
-    """Create configuration with a very low token limit for testing."""
+def low_token_limit_config():
+    """Create configuration with a very low token limit for testing.
+
+    Yields config and cleans up temporary file after test completes.
+    """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
         f.write("enable_context_injection: true\n")
         f.write("context_token_limit: 100\n")
         config_path = Path(f.name)
 
-    return Config(config_path)
+    yield Config(config_path)
+
+    # Cleanup temporary config file
+    config_path.unlink(missing_ok=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Implements functional tests for context injection (Test Category 2) per prd_testing.md Section 8.2
- All 5 test cases from T-2.1 through T-2.5 implemented and passing
- Additional edge case tests for comprehensive coverage (14 total tests)

## Test Cases
- [x] T-2.1: Verify context injected when editing related files
- [x] T-2.2: Verify injection token limit respected (<500 tokens)
- [x] T-2.3: Verify relevant context selected (not random snippets)
- [x] T-2.4: Verify injection can be disabled via config
- [x] T-2.5: Verify injection timing (appears when needed)

## Test plan
- [ ] Run `pytest tests/functional/test_context_injection.py -v`
- [ ] Verify all 14 tests pass
- [ ] Verify pre-commit hooks pass (black, isort, ruff, mypy, pytest)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)