### PR TITLE
Fix RuntimeWarning in MCP server startup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The Cross-File Context Links MCP Server provides automatic cross-file context in
 Run the MCP server directly:
 
 ```bash
-python -m xfile_context.mcp_server
+python -m xfile_context
 ```
 
 The server runs in stdio mode by default, which is compatible with Claude Code.
@@ -209,7 +209,7 @@ Add to your Claude Code MCP configuration (`~/.config/claude-code/mcp.json` or e
   "mcpServers": {
     "xfile_context": {
       "command": "/path/to/xfile_context/venv/bin/python",
-      "args": ["-m", "xfile_context.mcp_server"]
+      "args": ["-m", "xfile_context"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix RuntimeWarning that occurred when running `python -m xfile_context.mcp_server`
- Update README to use the correct command `python -m xfile_context` which uses the existing `__main__.py` entry point
- The warning was caused by the module being imported via `__init__.py` before being executed as `__main__`

## Test plan
- [x] Verify `python -m xfile_context` starts without RuntimeWarning
- [x] Verify old command `python -m xfile_context.mcp_server` still produces the warning (confirming fix)
- [x] Pre-commit checks pass (black, isort, ruff, mypy, pytest)
- [ ] User can follow updated README instructions without warnings

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)