### PR TITLE
Fix: read_with_context MCP tool returns no injected context on first read

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -75,13 +75,6 @@ Author: UNKNOWN
 URL: https://github.com/pallets/click/
 --------------------------------------------------------------------------------
 
-Package: colorama
-Version: 0.4.6
-License: BSD License
-Author: Jonathan Hartley <tartley@tartley.com>
-URL: https://github.com/tartley/colorama
---------------------------------------------------------------------------------
-
 Package: coverage
 Version: 7.12.0
 License: Apache-2.0
@@ -194,15 +187,8 @@ Author: Jukka Lehtosalo <jukka.lehtosalo@iki.fi>, Ivan Levkivskyi <levkivskyi@gm
 URL: https://github.com/mypyc/librt
 --------------------------------------------------------------------------------
 
-Package: mando
-Version: 0.7.1
-License: MIT License
-Author: Michele Lacchia
-URL: https://mando.readthedocs.org/
---------------------------------------------------------------------------------
-
 Package: mcp
-Version: 1.22.0
+Version: 1.23.1
 License: MIT License
 Author: Anthropic, PBC.
 URL: https://modelcontextprotocol.io
@@ -355,13 +341,6 @@ Author: Kirill Simonov
 URL: https://pyyaml.org/
 --------------------------------------------------------------------------------
 
-Package: radon
-Version: 6.0.1
-License: MIT License
-Author: Michele Lacchia
-URL: https://radon.readthedocs.org/
---------------------------------------------------------------------------------
-
 Package: referencing
 Version: 0.37.0
 License: MIT
@@ -395,13 +374,6 @@ Version: 0.14.7
 License: MIT License
 Author: "Astral Software Inc." <hey@astral.sh>
 URL: https://docs.astral.sh/ruff
---------------------------------------------------------------------------------
-
-Package: six
-Version: 1.17.0
-License: MIT License
-Author: Benjamin Peterson
-URL: https://github.com/benjaminp/six
 --------------------------------------------------------------------------------
 
 Package: sse-starlette


### PR DESCRIPTION
## Summary
- Implements lazy initialization for the CrossFileContextService
- Files are analyzed on-demand when `read_file_with_context` is called
- Context is available on first read without requiring eager full-project analysis

## Changes
- Add `_needs_analysis()` helper method to check if a file needs (re-)analysis
- Update `read_file_with_context()` to analyze files lazily before querying dependencies
- Update existing tests to add FileMetadata when manually injecting relationships
- Add new `TestLazyInitialization` test class with 6 comprehensive tests
- Update T-2.5 functional test to verify context via lazy initialization

## Test plan
- [x] All 68 service tests pass
- [x] All lazy initialization tests pass
- [x] Updated T-2.5 functional test passes
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, pytest-fast)

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)