### PR TITLE
Fix: Module classification and context injection bugs

### DIFF
--- a/tests/functional/test_context_injection.py
+++ b/tests/functional/test_context_injection.py
@@ -311,8 +311,11 @@ class TestContextInjection:
         assert "[Cross-File Context]" in result.injected_context
         assert "imports from" in result.injected_context.lower()
 
-        # Verify line numbers are included (helps locate definitions)
-        assert "(line " in result.injected_context or "line " in result.injected_context.lower()
+        # Verify symbols are included (with or without line numbers)
+        # Per Issue #116 Bug 3 fix: Line numbers show definition locations when available,
+        # and are omitted when target_line is None (rather than showing incorrect usage lines)
+        # Check that at least some symbols are mentioned (indicating dependency tracking works)
+        assert "()" in result.injected_context, "Symbol names with () should be present"
 
     def test_t_2_4_injection_disabled_via_config(
         self,


### PR DESCRIPTION
## Summary

This PR fixes three bugs discovered during UAT for Issue #46:

- **Bug 1: `builtins` module incorrectly classified as third-party** - Implemented hybrid approach using `sys.stdlib_module_names` (Python 3.10+) with fallback to comprehensive curated list for Python 3.9
- **Bug 2: False "file was deleted" warnings for stdlib/third-party modules** - Modified `_check_deleted_files()` to skip special marker paths like `<stdlib:ast>`, `<third-party:requests>`, `<unresolved:x>`
- **Bug 3: Dependency summary showed usage line instead of definition line** - Updated `_assemble_context()` to use `target_line` (definition location in dependency file) instead of `line_number` (usage location in source file) per TDD Section 3.8.3 and FR-13

## Test plan

- [ ] Run `pytest tests/test_import_detector.py::TestBuiltinsModuleClassification` - verifies Bug 1 fix
- [ ] Run `pytest tests/test_service.py::TestSpecialMarkerPathHandling` - verifies Bug 2 fix
- [ ] Run `pytest tests/test_service.py::TestDependencySummaryLineNumbers` - verifies Bug 3 fix
- [ ] Run full test suite `pytest tests/` - all 991 tests pass

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)