### PR TITLE
Fix read_with_context() idempotency issue (Issue #131)

### DIFF
--- a/src/xfile_context/service.py
+++ b/src/xfile_context/service.py
@@ -1125,7 +1125,9 @@ class CrossFileContextService:
         # symbols are DEFINED in the dependency file, not where they're USED
         # in the target file. This enables efficient snippet-based caching.
         context_parts.append("This file imports from:")
-        for target_file_path, rels in files_imported.items():
+        # Sort references by file path for deterministic output (Issue #131)
+        for target_file_path in sorted(files_imported.keys()):
+            rels = files_imported[target_file_path]
             symbols = []
             for rel in rels:
                 if rel.target_symbol:
@@ -1137,9 +1139,10 @@ class CrossFileContextService:
                         symbols.append(f"{rel.target_symbol}()")
                 else:
                     symbols.append(f"(line {rel.line_number})")
-            symbols_str = ", ".join(symbols[:3])  # Limit to 3 per file
-            if len(symbols) > 3:
-                symbols_str += f" (+{len(symbols) - 3} more)"
+            # Sort symbols for deterministic output (Issue #131)
+            symbols.sort()
+            # Print all symbols without truncation (Issue #131)
+            symbols_str = ", ".join(symbols)
             context_parts.append(f"- {Path(target_file_path).name}: {symbols_str}")
 
         context_parts.append("")


### PR DESCRIPTION
## Summary

- **Fix non-deterministic output** in `read_with_context()` by sorting references by file path and symbols alphabetically
- **Remove symbol truncation** that was hiding important dependency information with "(+N more)"
- **Add comprehensive tests** for deterministic/idempotent output behavior

## Root Cause

The context injection output was non-deterministic because:
1. References were not sorted (depended on dictionary insertion order)
2. Symbols within each reference were not sorted
3. Symbol truncation at 3 items caused information loss

## Changes

**src/xfile_context/service.py:1128-1146**
- Sort `files_imported` dictionary keys alphabetically when iterating
- Sort symbols list alphabetically before joining
- Remove `[:3]` truncation and `(+N more)` suffix

**tests/test_service.py** (new TestDeterministicOutput class)
- `test_assemble_context_sorts_references_by_file_path`
- `test_assemble_context_sorts_symbols_within_reference`
- `test_assemble_context_prints_all_symbols_no_truncation`
- `test_assemble_context_idempotent_output`

## Test plan

- [x] All 81 tests in test_service.py pass
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, pytest)
- [ ] Manual verification: Run `read_with_context()` twice on the same file and diff results

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)