### PR TITLE
Add reference extraction for decorators and metaclasses

### DIFF
--- a/src/xfile_context/models.py
+++ b/src/xfile_context/models.py
@@ -66,6 +66,8 @@ class ReferenceType:
     FUNCTION_CALL = "function_call"  # foo() or module.foo()
     CLASS_REFERENCE = "class_reference"  # class Foo(Bar): where Bar is imported
     ATTRIBUTE_ACCESS = "attribute_access"  # module.attribute
+    DECORATOR = "decorator"  # @decorator applied to function/class
+    METACLASS = "metaclass"  # class Foo(metaclass=Meta)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Extends `DecoratorDetector` and `MetaclassDetector` to extract `SymbolReference` entries
- Adds `ReferenceType.DECORATOR` and `ReferenceType.METACLASS` to models.py
- Adds comprehensive tests for reference extraction

## Changes
1. **models.py**: Added `DECORATOR` and `METACLASS` to `ReferenceType` class
2. **decorator_detector.py**: Updated `extract_symbols()` to create decorator references
3. **metaclass_detector.py**: Updated `extract_symbols()` to create metaclass references  
4. **test_dynamic_pattern_detectors.py**: Added tests for decorator and metaclass reference extraction

## Impact
This enables:
- Tracking which files depend on specific decorators
- Showing decorator definitions in "Recent definitions" section
- Warning when editing a decorator that's used in many files
- Complete dependency graph for metaclass relationships

## Testing
- All existing tests pass
- Added 4 new tests for decorator and metaclass reference extraction
- Verified decorator references are extracted for:
  - Simple decorators (@custom_decorator)
  - Module-qualified decorators (@module.decorator)
  - Class decorators (@dataclass)
- Verified metaclass references are extracted for:
  - Simple metaclasses (metaclass=CustomMeta)
  - Module-qualified metaclasses (metaclass=mymodule.CustomMeta)

## Complexity
Estimated 1.5 days (as documented in issue #141)

Resolves #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)