### PR TITLE
Fix duplicate entries in recent definitions section (Issue #144 follow-up)

### DIFF
--- a/src/xfile_context/service.py
+++ b/src/xfile_context/service.py
@@ -1160,10 +1160,11 @@ class CrossFileContextService:
         context_parts.append("")
 
         # Deduplicate relationships for recent definitions section (Issue #144)
+        # This is assembly-level deduplication (complements graph-level deduplication in PR #145).
         # Key: (target_file, target_line, source_file, relationship_type)
         # Excludes usage line number because a single function definition
         # is sufficient for all usages in the file for now.
-        seen_definitions: Set[Tuple[str, Optional[int], str, Any]] = set()
+        seen_dedup_keys: Set[Tuple[str, Optional[int], str, str]] = set()
         deduplicated_rels: List[Relationship] = []
         for rel in prioritized:
             dedup_key = (
@@ -1172,8 +1173,8 @@ class CrossFileContextService:
                 rel.source_file,
                 rel.relationship_type,
             )
-            if dedup_key not in seen_definitions:
-                seen_definitions.add(dedup_key)
+            if dedup_key not in seen_dedup_keys:
+                seen_dedup_keys.add(dedup_key)
                 deduplicated_rels.append(rel)
 
         snippets_added = 0


### PR DESCRIPTION
## Summary

- Adds deduplication at the "recent definitions" assembly level to address Issue #144 comment
- Deduplication key excludes usage line number, using: (target_file, target_line, source_file, relationship_type)
- A single function definition is now shown once regardless of how many times it's used in the file
- PR #145 fixed duplicates at the graph level; this PR fixes duplicates at the context assembly level

## Test plan

- [x] Added `TestRecentDefinitionsDeduplication` test class with 4 tests:
  - test_deduplicate_same_function_multiple_usages
  - test_different_functions_not_deduplicated  
  - test_same_function_different_relationship_types_deduplicated
  - test_dedup_key_includes_target_line
- [x] All 1142 tests pass
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, pytest)

References #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)