### PR TITLE
Update analyze_metrics.py path examples for new log architecture

### DIFF
--- a/scripts/analyze_metrics.py
+++ b/scripts/analyze_metrics.py
@@ -14,7 +14,7 @@ Features:
 - Human-readable report output
 
 Usage:
-    python scripts/analyze_metrics.py .xfile_context/session_metrics.jsonl
+    python scripts/analyze_metrics.py ~/.cross_file_context/session_metrics/*.jsonl
     python scripts/analyze_metrics.py path/to/metrics1.jsonl path/to/metrics2.jsonl
 
 Related Requirements:
@@ -740,8 +740,8 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python analyze_metrics.py .cross_file_context_logs/session_metrics.jsonl
-    python analyze_metrics.py metrics1.jsonl metrics2.jsonl
+    python analyze_metrics.py ~/.cross_file_context/session_metrics/*.jsonl
+    python analyze_metrics.py path/to/metrics1.jsonl path/to/metrics2.jsonl
         """,
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Update documentation examples in `scripts/analyze_metrics.py` to reflect the new default metrics path from Issue #150 (logging architecture cleanup)
- The metrics are now stored in `~/.cross_file_context/session_metrics/` instead of the old `.cross_file_context_logs/` directory

## Changes
- Updated docstring usage example (line 17)
- Updated argparse epilog example (line 743)

## Test plan
- [x] Verify pre-commit hooks pass (black, isort, ruff, mypy, pytest)
- [ ] Manual verification that updated paths match the new log architecture from #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)